### PR TITLE
Update jquery.lazyload.js

### DIFF
--- a/jquery.lazyload.js
+++ b/jquery.lazyload.js
@@ -29,7 +29,8 @@
             skip_invisible  : false,
             appear          : null,
             load            : null,
-            placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"
+            placeholder     : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC",
+            callback        : null
         };
 
         function update() {
@@ -125,6 +126,9 @@
                                 var elements_left = elements.length;
                                 settings.load.call(self, elements_left, settings);
                             }
+                            if (settings.callback) {
+                                settings.callback($self);
+                            }                            
                         })
                         .attr("src", $self.attr("data-" + settings.data_attribute));
                 }


### PR DESCRIPTION
Using this callback option/setting, developers will be able to perform additional action upon lazy load.

`    $("img[data-original]").lazyload({
        effect : "fadeIn",
        callback: function(self) {
            console.log('callback', self);
        }
    });
`